### PR TITLE
Coderefs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+
+  * Allow completion list to be a coderef.
+  * Allow a custom formatter to be provided.
+  * Allow completion character to be something other than <tab>.
+
 1.402  Wed, 13 Jul 2011 17:41:47 +0200
   * First stand-alone release to CPAN. This release is identical to version 1.402
     as shipped with the perl code as of 5.9.3.

--- a/examples/formatter.pl
+++ b/examples/formatter.pl
@@ -1,0 +1,48 @@
+use Data::Dumper;
+use Term::Complete;
+use Term::ReadKey;
+use List::Util qw/max/;
+use List::MoreUtils qw/natatime/;
+
+my @animals = (qw(
+	aardvark bear cat caterpillar chicken cow dog donkey elephant
+	fox goat guinea-pig horse iguana jackal kangaroo llama monkey
+	mule newt numbat octopus peacock platypus possum quail rabbit
+	rat seahorse sheep shrew slug tarantula urchin vulture walrus
+	), 'x-ray fish', qw(yak zebra));
+
+sub find_animals
+{
+	my $string = shift;
+	sort grep(/^\Q$string/, @animals);
+}
+
+sub format_choices
+{
+	my @choices  = @_;
+	my ($wchar)  = GetTerminalSize();
+	my $width    = 3 + max map { length } @choices;
+	my $columns  = int( $wchar / $width ) || 1;
+	my $iter     = natatime $columns, @choices;
+	
+	my $return = "\r\n";
+	while (my @vals = $iter->())
+	{
+		$return .= join q(), map { sprintf("%-${width}s", $_) } @vals;
+		$return .= "\r\n";
+	}
+	return $return;
+};
+
+my @chosen;
+
+print "Please enter some animals. Enter a blank line to finish.\n";
+
+while (1)
+{
+	my $choice = Complete("animal> ", \&find_animals, \&format_choices);
+	last unless $choice =~ /[a-z]/i;
+	push @chosen, $choice;
+}
+
+print Dumper \@chosen;

--- a/examples/simple.pl
+++ b/examples/simple.pl
@@ -1,0 +1,23 @@
+use Data::Dumper;
+use Term::Complete;
+
+my @animals = (qw(
+	aardvark bear cat caterpillar chicken cow dog donkey elephant
+	fox goat guinea-pig horse iguana jackal kangaroo llama monkey
+	mule newt numbat octopus peacock platypus possum quail rabbit
+	rat seahorse sheep shrew slug tarantula urchin vulture walrus
+	), 'x-ray fish', qw(yak zebra
+	));
+
+my @chosen;
+
+print "Please enter some animals. Enter a blank line to finish.\n";
+
+while (1)
+{
+	my $choice = Complete("animal> ", \@animals);
+	last unless $choice =~ /[a-z]/i;
+	push @chosen, $choice;
+}
+
+print Dumper \@chosen;

--- a/lib/Term/Complete.pm
+++ b/lib/Term/Complete.pm
@@ -74,42 +74,42 @@ CONFIG: {
     $erase1 =   "\177";
     $erase2 =   "\010";
     foreach my $s (qw(/bin/stty /usr/bin/stty)) {
-	if (-x $s) {
-	    $tty_raw_noecho = "$s raw -echo";
-	    $tty_restore    = "$s -raw echo";
-	    $tty_safe_restore = $tty_restore;
-	    $stty = $s;
-	    last;
-	}
+        if (-x $s) {
+            $tty_raw_noecho = "$s raw -echo";
+            $tty_restore    = "$s -raw echo";
+            $tty_safe_restore = $tty_restore;
+            $stty = $s;
+            last;
+        }
     }
 }
 
 sub Complete {
     my($prompt, @cmp_lst, $cmp, $test, $l, @match);
     my ($return, $r) = ("", 0);
-
+    
     $return = "";
     $r      = 0;
-
+    
     $prompt = shift;
     if (ref $_[0] || $_[0] =~ /^\*/) {
-	@cmp_lst = sort @{$_[0]};
+        @cmp_lst = sort @{$_[0]};
     }
     else {
-	@cmp_lst = sort(@_);
+        @cmp_lst = sort(@_);
     }
-
+    
     # Attempt to save the current stty state, to be restored later
     if (defined $stty && defined $tty_saved_state && $tty_saved_state eq '') {
-	$tty_saved_state = qx($stty -g 2>/dev/null);
-	if ($?) {
-	    # stty -g not supported
-	    $tty_saved_state = undef;
-	}
-	else {
-	    $tty_saved_state =~ s/\s+$//g;
-	    $tty_restore = qq($stty "$tty_saved_state" 2>/dev/null);
-	}
+        $tty_saved_state = qx($stty -g 2>/dev/null);
+        if ($?) {
+            # stty -g not supported
+            $tty_saved_state = undef;
+        }
+        else {
+            $tty_saved_state =~ s/\s+$//g;
+            $tty_restore = qq($stty "$tty_saved_state" 2>/dev/null);
+        }
     }
     system $tty_raw_noecho if defined $tty_raw_noecho;
     LOOP: {
@@ -133,24 +133,24 @@ sub Complete {
                     }
                     last CASE;
                 };
-
+                
                 # (^D) completion list
                 $_ eq $complete && do {
                     print(join("\r\n", '', grep(/^\Q$return/, @cmp_lst)), "\r\n");
                     redo LOOP;
                 };
-
+                
                 # (^U) kill
                 $_ eq $kill && do {
                     if ($r) {
-                        $r	= 0;
-			$return	= "";
+                        $r       = 0;
+                        $return  = "";
                         print("\r\n");
                         redo LOOP;
                     }
                     last CASE;
                 };
-
+                
                 # (DEL) || (BS) erase
                 ($_ eq $erase1 || $_ eq $erase2) && do {
                     if($r) {
@@ -160,7 +160,7 @@ sub Complete {
                     }
                     last CASE;
                 };
-
+                
                 # printable char
                 ord >= 32 && do {
                     $return .= $_;
@@ -171,15 +171,15 @@ sub Complete {
             }
         }
     }
-
+    
     # system $tty_restore if defined $tty_restore;
     if (defined $tty_saved_state && defined $tty_restore && defined $tty_safe_restore)
     {
-	system $tty_restore;
-	if ($?) {
-	    # tty_restore caused error
-	    system $tty_safe_restore;
-	}
+        system $tty_restore;
+        if ($?) {
+            # tty_restore caused error
+            system $tty_safe_restore;
+        }
     }
     print("\n");
     $return;

--- a/lib/Term/Complete.pm
+++ b/lib/Term/Complete.pm
@@ -66,8 +66,8 @@ Wayne Thompson
 
 =cut
 
-our($complete, $kill, $erase1, $erase2, $tty_raw_noecho, $tty_restore, $stty, $tty_safe_restore);
-our($tty_saved_state) = '';
+our ($complete, $kill, $erase1, $erase2, $tty_raw_noecho, $tty_restore, $stty, $tty_safe_restore);
+our ($tty_saved_state) = '';
 CONFIG: {
     $complete = "\004";
     $kill     = "\025";
@@ -85,16 +85,18 @@ CONFIG: {
 }
 
 sub Complete {
-    my($prompt, @cmp_lst, $cmp, $test, $l, @match);
-    my ($return, $r) = ("", 0);
+    my $prompt = shift;
     
-    $prompt = shift;
-    if (ref $_[0] || $_[0] =~ /^\*/) {
-        @cmp_lst = sort @{$_[0]};
-    }
-    else {
-        @cmp_lst = sort(@_);
-    }
+    my @cmp_lst = do {
+        if (ref $_[0] || $_[0] =~ /^\*/) {
+            sort @{$_[0]};
+        }
+        else {
+            sort(@_);
+        }
+    };
+    
+    my ($return, $r) = ("", 0);
     
     # Attempt to save the current stty state, to be restored later
     if (defined $stty && defined $tty_saved_state && $tty_saved_state eq '') {
@@ -116,10 +118,10 @@ sub Complete {
             CASE: {
                 # (TAB) attempt completion
                 $_ eq "\t" && do {
-                    @match = grep(/^\Q$return/, @cmp_lst);
+                    my @match = grep(/^\Q$return/, @cmp_lst);
                     unless ($#match < 0) {
-                        $l = length($test = shift(@match));
-                        foreach $cmp (@match) {
+                        my $l = length(my $test = shift(@match));
+                        foreach my $cmp (@match) {
                             until (substr($cmp, 0, $l) eq substr($test, 0, $l)) {
                                 $l--;
                             }

--- a/lib/Term/Complete.pm
+++ b/lib/Term/Complete.pm
@@ -88,9 +88,6 @@ sub Complete {
     my($prompt, @cmp_lst, $cmp, $test, $l, @match);
     my ($return, $r) = ("", 0);
     
-    $return = "";
-    $r      = 0;
-    
     $prompt = shift;
     if (ref $_[0] || $_[0] =~ /^\*/) {
         @cmp_lst = sort @{$_[0]};

--- a/lib/Term/Complete.pm
+++ b/lib/Term/Complete.pm
@@ -47,7 +47,7 @@ The following command characters are defined:
 =item E<lt>tabE<gt>
 
 Attempts word completion.
-Cannot be changed.
+Defined by I<$Term::Complete::tabchar>.
 
 =item ^D
 
@@ -70,23 +70,20 @@ Defined by I<$Term::Complete::erase1> and I<$Term::Complete::erase2>.
 
 Bell sounds when word completion fails.
 
-=head1 BUGS
-
-The completion character E<lt>tabE<gt> cannot be changed.
-
 =head1 AUTHOR
 
 Wayne Thompson
 
 =cut
 
-our ($complete, $kill, $erase1, $erase2, $tty_raw_noecho, $tty_restore, $stty, $tty_safe_restore);
+our ($tabchar, $complete, $kill, $erase1, $erase2, $tty_raw_noecho, $tty_restore, $stty, $tty_safe_restore);
 our ($tty_saved_state) = '';
 CONFIG: {
+    $tabchar  = "\t";
     $complete = "\004";
     $kill     = "\025";
-    $erase1 =   "\177";
-    $erase2 =   "\010";
+    $erase1   = "\177";
+    $erase2   = "\010";
     foreach my $s (qw(/bin/stty /usr/bin/stty)) {
         if (-x $s) {
             $tty_raw_noecho = "$s raw -echo";
@@ -148,7 +145,7 @@ sub Complete {
         while (($_ = getc(STDIN)) ne "\r") {
             CASE: {
                 # (TAB) attempt completion
-                $_ eq "\t" && do {
+                $_ eq $tabchar && do {
                     my @match = $cmp_lst->($return);
                     unless ($#match < 0) {
                         my $l = length(my $test = shift(@match));


### PR DESCRIPTION
Allows a coderef to be passed to calculate completion list on demand.

Allows a coderef to be passed to format list of potential completions.

Fixes bug that completion is hard-coded to "\t".

Adds some examples.
